### PR TITLE
docs(song.txt): add title, author of song and separate chorus and verses

### DIFF
--- a/src/song.txt
+++ b/src/song.txt
@@ -1,6 +1,7 @@
 Chest Pain (I Love)
 By: Malcolm Todd
 
+[Chorus]
 My chest is hurting, my feet can't fall out of bed
 I don't know where to go, so I'll lay here instead
 With my symptoms, symptoms of sorrow and dread
@@ -8,6 +9,8 @@ They all said it would fade, but again and again
 I love, I love
 I love, I love, I love
 I love, I love, I love
+
+[Verse]
 I've been so busy
 But now that I'm alone
 Where did you go?
@@ -18,6 +21,8 @@ Please, I wanna see what we would be if you were by my side
 Make me feel lonely, soon
 You might not know me, I wish I could lie
 But I can't deny
+
+[Chorus]
 My chest is hurting, my feet can't fall out of bed
 I don't know where to go, so I'll lay here instead
 With my symptoms, symptoms of sorrow and dread
@@ -25,6 +30,8 @@ They all said it would fade, but again and again
 I love, I love
 I love, I love, I love
 I love, I love, I love
+
+[Chorus]
 I'm hurting, I'm stuck in my bed
 I don't know where to go, so I'll lay here instead
 With my symptoms, symptoms of sorrow and dread

--- a/src/song.txt
+++ b/src/song.txt
@@ -1,3 +1,6 @@
+Chest Pain (I Love)
+By: Malcolm Todd
+
 My chest is hurting, my feet can't fall out of bed
 I don't know where to go, so I'll lay here instead
 With my symptoms, symptoms of sorrow and dread


### PR DESCRIPTION
Problems: song.txt does not cite the title and author of the song. Lyrics are also compressed into one body with no division of parts, making it harder to read.

Solutions: add title and author to the first two lines of song.txt. Implement the division of the chorus and verses.